### PR TITLE
reqWrapper as Readable stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "chai": "^4.2.0",
     "mocha": "^7.2.0",
     "nyc": "^15.1.0",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "body-parser": "^1.19.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -22,7 +22,7 @@ module.exports = (config = {}) => {
     const resWrapper = new HttpResponse(res, uServer)
 
     const method = reqWrapper.method
-    if (method !== 'GET' && method !== 'HEAD') {
+    if (method !== 'HEAD') {
       let buffer
 
       res.onData((bytes, isLast) => {

--- a/tests/0http-integration.spec.js
+++ b/tests/0http-integration.spec.js
@@ -2,6 +2,7 @@
 const expect = require('chai').expect
 const request = require('supertest')
 const { createReadStream } = require('fs')
+var jsonParser = require('body-parser').json
 
 describe('0http Web Framework - Low HTTP Server Integration', () => {
   const baseUrl = 'http://localhost:' + process.env.PORT
@@ -29,8 +30,16 @@ describe('0http Web Framework - Low HTTP Server Integration', () => {
       next()
     })
 
+    router.post('/echo2', (req, res) => {
+      let stringified = JSON.stringify(req.body)
+      res.end(stringified)
+    })
+
+    router.use(jsonParser())
+
     router.post('/echo', (req, res) => {
-      res.end(req.body)
+      let stringified = JSON.stringify(req.body)
+      res.end(stringified)
     })
 
     router.get('/qs', (req, res) => {
@@ -120,6 +129,16 @@ describe('0http Web Framework - Low HTTP Server Integration', () => {
       .expect(200)
       .then((response) => {
         expect(response.text).to.equal(JSON.stringify({ name: 'john' }))
+      })
+  })
+
+  it('should NOT parse request data on POST /echo2', async () => {
+    await request(baseUrl)
+      .post('/echo2')
+      .send({ name: 'john' })
+      .expect(200)
+      .then((response) => {
+        expect(response.text).to.equal(JSON.stringify({}))
       })
   })
 

--- a/tests/0http-integration.spec.js
+++ b/tests/0http-integration.spec.js
@@ -2,7 +2,7 @@
 const expect = require('chai').expect
 const request = require('supertest')
 const { createReadStream } = require('fs')
-var jsonParser = require('body-parser').json
+const jsonParser = require('body-parser').json
 
 describe('0http Web Framework - Low HTTP Server Integration', () => {
   const baseUrl = 'http://localhost:' + process.env.PORT
@@ -31,14 +31,14 @@ describe('0http Web Framework - Low HTTP Server Integration', () => {
     })
 
     router.post('/echo2', (req, res) => {
-      let stringified = JSON.stringify(req.body)
+      const stringified = JSON.stringify(req.body)
       res.end(stringified)
     })
 
     router.use(jsonParser())
 
     router.post('/echo', (req, res) => {
-      let stringified = JSON.stringify(req.body)
+      const stringified = JSON.stringify(req.body)
       res.end(stringified)
     })
 


### PR DESCRIPTION
This is a breaking change that reimplements the `reqWrapper` as a Readable stream. The wrapper creates empty `req.body` object, BUT no longer deals with populating it. Native HTTP module also does not populate `req.body` by default.