### PR TITLE
Clustering attempt will show warning on non-Linux platforms.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -2,14 +2,8 @@ const uWS = require('uWebSockets.js')
 const { Writable } = require('stream')
 const { toString, toLowerCase } = require('./utils/string')
 const { forEach } = require('./utils/object')
+require('./utils/os-compat-check')
 const REQUEST_EVENT = 'request'
-
-const {worker} = require('cluster')
-const {threadId } = require('worker_threads')
-
-if (require('os').platform !== 'linux' && ( (worker && worker.id) || threadId === 1)) {
-  console.log('Be aware that uWebSockets.js clustering only works on Linux and depends on its kernel features. See <https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050> for more info') // https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050
-}
 
 module.exports = (config = {}) => {
   let handler = (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,13 @@ const { toString, toLowerCase } = require('./utils/string')
 const { forEach } = require('./utils/object')
 const REQUEST_EVENT = 'request'
 
+const {worker} = require('cluster')
+const {threadId } = require('worker_threads')
+
+if (require('os').platform !== 'linux' && ( (worker && worker.id) || threadId === 1)) {
+  console.log('Be aware that uWebSockets.js clustering only works on Linux and depends on its kernel features. See <https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050> for more info') // https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050
+}
+
 module.exports = (config = {}) => {
   let handler = (req, res) => {
     res.statusCode = 404

--- a/src/utils/os-compat-check.js
+++ b/src/utils/os-compat-check.js
@@ -1,0 +1,6 @@
+const {worker} = require('cluster')
+const {threadId } = require('worker_threads')
+
+if (require('os').platform !== 'linux' && ( (worker && worker.id === 1) || threadId === 1)) {
+	console.log('Be aware that uWebSockets.js clustering only works on Linux and depends on its kernel features. See <https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050> for more info') // https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050
+}


### PR DESCRIPTION
uWebSockets.js clustering doesn't really work on any platform other than `Linux`, since [it depends on `Linux` kernel features](https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050). This can be proven with this code: 

```
const cero = require('../src/server')
const { Worker, isMainThread, threadId } = require('worker_threads')
const numCPUs = require('os').cpus().length

if (isMainThread) {
  console.log(`Master ${process.pid} is running`)
  for (let i = 0; i < numCPUs; i++) {
    new Worker(__filename)
  }
} else {
  const server = cero({})
  server.on('request', (req, res) => {
    res.end(threadId.toString()) // willl always send '1' on non-Linux platforms.
  })

  server.listen(3000, () => {
    console.log(`Server(${threadId}) listening on http://0.0.0.0:3000`)
  })
}

```

 As such, we need to show warning to the users, so they are aware of the issue and why there is no performance gain.

