### PR TITLE
2.1.1

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -152,7 +152,10 @@ class HttpResponse extends Writable {
   }
 
   setHeader (name, value) {
-    this.__headers[toLowerCase(name)] = [name, toString(value)]
+    let filterRegEx = new RegExp(`^${name},`)
+    let toSet = toString(value)
+    toSet = toSet.replace(filterRegEx, '')
+    this.__headers[toLowerCase(name)] = [name, toSet]
   }
 
   getHeaderNames () {

--- a/src/server.js
+++ b/src/server.js
@@ -21,9 +21,6 @@ module.exports = (config = {}) => {
 
   const uServer = uWS[appType](config).any('/*', (res, req) => {
     res.finished = false
-    res.onAborted(() => {
-      res.finished = true
-    })
 
     const reqWrapper = new HttpRequest(req)
     const resWrapper = new HttpResponse(res, uServer)
@@ -139,6 +136,10 @@ class HttpResponse extends Writable {
 
     this.__headers = {}
     this.headersSent = false
+
+    this.res.onAborted(() => {
+      this.finished = this.res.finished = true
+    })
 
     this.on('pipe', _ => {
       if (this.finished) return

--- a/src/server.js
+++ b/src/server.js
@@ -152,7 +152,7 @@ class HttpResponse extends Writable {
   }
 
   setHeader (name, value) {
-    let filterRegEx = new RegExp(`^${name},`)
+    const filterRegEx = new RegExp(`^${name},`)
     let toSet = toString(value)
     toSet = toSet.replace(filterRegEx, '')
     this.__headers[toLowerCase(name)] = [name, toSet]

--- a/src/server.js
+++ b/src/server.js
@@ -61,16 +61,18 @@ module.exports = (config = {}) => {
       handler = cb
     },
 
-    close () {
+    close (cb) {
       clearInterval(timer)
       uWS.us_listen_socket_close(uServer._socket)
+      if (!cb) return
+      return cb()
     }
   }
   facade.listen = facade.start = (port, cb) => {
     uServer.listen(port, socket => {
       uServer._socket = socket
 
-      cb(socket)
+      if (cb) cb(socket)
     })
   }
 


### PR DESCRIPTION
1. Squashed further `aborted` bugs (#1 was more persistent, than we thought 😂). My other project, [`Fyrejet`](https://github.com/fyrejet/fyrejet) framework uses its own uWebSockets.js compatibility layer that was also based upon `0http`'s `low` server. Naturally, I wanted to replace that compatibility layer with `low-http-server` to maintain less code in the long-term. Unfortunately, `express`'s tests that my other project uses revealed a regression with `res.sendFile`:

```
  1) res
       .sendFile(path)
         should not error if the client aborts:
     Uncaught Error: the string "Invalid access of discarded (invalid, deleted) uWS.HttpResponse/SSLHttpResponse." was thrown, throw an Error :)
      at process._fatalException (internal/process/execution.js:165:25)
```

That means `aborted` checks that we have here are NOT fully complete. This PR changes that.

2. Squashed header bugs. `Fyrejet` also uses some Restana's tests, since its core is based on `Restana` and it borrows Restana's `res.send` in certain operating modes. It is also possible this error might occur with unmodified `Restana`, but I haven't checked it yet. Unfortunately, it appears that sometimes, header contents may include header name. I don't like the fix, but it's the best I could think of.

```
  1) All Responses
       should GET 200 and html content on /html-string:
     Error: expected "content-type" of "text/html; charset=utf-8", got "content-type,text/html; charset=utf-8"
      at Test._assertHeader (node_modules/supertest/lib/test.js:249:12)
      at Test._assertFunction (node_modules/supertest/lib/test.js:283:11)
      at Test.assert (node_modules/supertest/lib/test.js:173:18)
      at localAssert (node_modules/supertest/lib/test.js:131:12)
      at /Volumes/Work/fyrejet/node_modules/supertest/lib/test.js:128:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:716:12)
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/index.js:916:18)
      at endReadableNT (_stream_readable.js:1221:12)
      at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

3. Minor callback changes with `facade.close` and `facade.listen` funcs (for convenience).
