### PR TITLE
Fix os-compat-check on Node.js w/o worker_threads

### DIFF
--- a/src/utils/os-compat-check.js
+++ b/src/utils/os-compat-check.js
@@ -2,11 +2,9 @@ const { worker } = require('cluster')
 let threadId
 try {
   threadId = require('worker_threads').threadId
-}
-catch (err) {
+} catch (err) {
   threadId = 0
 }
-
 
 if (require('os').platform !== 'linux' && ((worker && worker.id === 1) || threadId === 1)) {
   console.log('Be aware that uWebSockets.js clustering only works on Linux and depends on its kernel features. See <https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050> for more info') // https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050

--- a/src/utils/os-compat-check.js
+++ b/src/utils/os-compat-check.js
@@ -1,5 +1,12 @@
 const { worker } = require('cluster')
-const { threadId } = require('worker_threads')
+let threadId
+try {
+  threadId = require('worker_threads').threadId
+}
+catch (err) {
+  threadId = 0
+}
+
 
 if (require('os').platform !== 'linux' && ((worker && worker.id === 1) || threadId === 1)) {
   console.log('Be aware that uWebSockets.js clustering only works on Linux and depends on its kernel features. See <https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050> for more info') // https://github.com/uNetworking/uWebSockets.js/issues/214#issuecomment-547589050


### PR DESCRIPTION
Fixes https://github.com/jkyberneees/low-http-server/issues/8: previously, low-http-server would fail on Node.js 10 & 11, if `worker_threads` were not enabled