### PR TITLE
restrict from being able to send headers after write

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -67,6 +67,8 @@ class HttpResponse extends Writable {
 
   write (data) {
     if (this.finished) return
+    this.writeAllHeaders()
+    this.headersSent = true
 
     this.res.write(data)
   }
@@ -95,7 +97,9 @@ class HttpResponse extends Writable {
     function doWrite (res) {
       res.res.writeStatus(`${res.statusCode} ${res.statusMessage}`)
 
-      res.writeAllHeaders()
+      if(!res.headersSent){
+        res.writeAllHeaders()
+      }
 
       res.finished = true
       res.res.end(data)


### PR DESCRIPTION
after fastify v3.28 and v4, they implement trailer and use res.write to send payload before res.end. It cause problem that make the request pending forever. After searching, i found that your low-http-framework have some limitation because you send header on end method, so if we use res.write before, then it means we send header after writing data . I only add some conditions to send header in write method and refuse to send header in end method if we use write method.