### PR TITLE
add writeAllHeaders in write method

### DIFF
--- a/src/response.js
+++ b/src/response.js
@@ -67,6 +67,7 @@ class HttpResponse extends Writable {
 
   write (data) {
     if (this.finished) return
+    this.writeAllHeaders()
 
     this.res.write(data)
   }


### PR DESCRIPTION
recently in fastify v3.28 and v4, they use `res.write` before `res.end` and it cause problem because yours low-http-server is writing header at 'res.end'. If we send header after sending data, the status will be pending forever (i don't know about this, probably bug at uWebSocket.js itself). I only add 'res.write' in write method so that it can't send header after send data to client.