### PR TITLE
add writeAllHeaders in write method

### DIFF
--- a/demos/basic.js
+++ b/demos/basic.js
@@ -2,7 +2,8 @@ const cero = require('./../src/server')
 
 const server = cero({})
 server.on('request', (req, res) => {
-  res.end('Hello World!')
+  res.write('Hello World!')
+  res.end()
 })
 
 server.listen(3000, () => {

--- a/src/request.js
+++ b/src/request.js
@@ -1,11 +1,12 @@
 const { Readable } = require('stream')
 const { forEach } = require('./utils/object')
 const CLOSE_EVENT = 'close'
-let closeHandler = ()=>{}
 
 class HttpRequest extends Readable {
-  constructor (uRequest, uResponse) {
+  constructor (uRequest) {
     super()
+
+    var self = this
 
     const oldThisOn = this.on.bind(this)
     const oldThisOnce = this.once.bind(this)
@@ -14,9 +15,11 @@ class HttpRequest extends Readable {
       return oldThisOnce(eventName, listener)
     }
 
+    this.closeHandler = () => {}
+
     this.on = function (eventName, listener) {
       if (eventName === CLOSE_EVENT) {
-        closeHandler = listener
+        self.closeHandler = listener
         return
       }
       return oldThisOn(eventName, listener)
@@ -34,10 +37,6 @@ class HttpRequest extends Readable {
 
     uRequest.forEach((header, value) => {
       this.headers[header] = value
-    })
-
-    uResponse.onAborted(() => {
-      closeHandler()
     })
   }
 

--- a/src/request.js
+++ b/src/request.js
@@ -6,20 +6,22 @@ class HttpRequest extends Readable {
   constructor (uRequest) {
     super()
 
-    var self = this
-
     const oldThisOn = this.on.bind(this)
     const oldThisOnce = this.once.bind(this)
 
-    this.once = function (eventName, listener) {
+    this.closeHandler = []
+
+    this.once = (eventName, listener)=>{
+      if (eventName === CLOSE_EVENT) {
+        this.closeHandler.push(listener)
+        return
+      }
       return oldThisOnce(eventName, listener)
     }
 
-    this.closeHandler = () => {}
-
-    this.on = function (eventName, listener) {
+    this.on =  (eventName, listener)=>{
       if (eventName === CLOSE_EVENT) {
-        self.closeHandler = listener
+        this.closeHandler.push(listener)
         return
       }
       return oldThisOn(eventName, listener)

--- a/src/request.js
+++ b/src/request.js
@@ -1,9 +1,26 @@
 const { Readable } = require('stream')
 const { forEach } = require('./utils/object')
+const CLOSE_EVENT = 'close'
+let closeHandler = ()=>{}
 
 class HttpRequest extends Readable {
-  constructor (uRequest) {
+  constructor (uRequest, uResponse) {
     super()
+
+    const oldThisOn = this.on.bind(this)
+    const oldThisOnce = this.once.bind(this)
+
+    this.once = function (eventName, listener) {
+      return oldThisOnce(eventName, listener)
+    }
+
+    this.on = function (eventName, listener) {
+      if (eventName === CLOSE_EVENT) {
+        closeHandler = listener
+        return
+      }
+      return oldThisOn(eventName, listener)
+    }
 
     const q = uRequest.getQuery()
     this.req = uRequest
@@ -17,6 +34,10 @@ class HttpRequest extends Readable {
 
     uRequest.forEach((header, value) => {
       this.headers[header] = value
+    })
+
+    uResponse.onAborted(() => {
+      closeHandler()
     })
   }
 

--- a/src/response.js
+++ b/src/response.js
@@ -30,7 +30,7 @@ class HttpResponse extends Writable {
   writeAllHeaders () {
     if (this.headersSent) return
 
-    this.res.writeHeader('Date', this.server._date)
+    // this.res.writeHeader('Date', this.server._date)
 
     Object.keys(this.__headers).forEach(key => {
       if (key.toLowerCase() === 'content-length') return

--- a/src/response.js
+++ b/src/response.js
@@ -67,6 +67,7 @@ class HttpResponse extends Writable {
 
   write (data) {
     if (this.finished) return
+    this.writeAllHeaders()
 
     this.res.write(data)
   }

--- a/src/response.js
+++ b/src/response.js
@@ -2,11 +2,12 @@ const { Writable } = require('stream')
 const { toLowerCase } = require('./utils/string')
 const HttpResponseSocket = require('./responseSocket')
 const CLOSE_EVENT = 'close'
-let closeHandler = ()=>{}
 
 class HttpResponse extends Writable {
   constructor (uResponse, reqWrapper) {
     super()
+
+    var self = this
 
     const oldThisOn = this.on.bind(this)
     const oldThisOnce = this.once.bind(this)
@@ -15,9 +16,11 @@ class HttpResponse extends Writable {
       return oldThisOnce(eventName, listener)
     }
 
+    this.closeHandler = () => {}
+
     this.on = function (eventName, listener) {
       if (eventName === CLOSE_EVENT) {
-        closeHandler = listener
+        self.closeHandler = listener
         return
       }
       return oldThisOn(eventName, listener)
@@ -35,7 +38,7 @@ class HttpResponse extends Writable {
 
     this.res.onAborted(() => {
       this.finished = this.res.finished = true
-      closeHandler()
+      self.closeHandler()
       reqWrapper.closeHandler()
     })
 

--- a/src/response.js
+++ b/src/response.js
@@ -5,7 +5,7 @@ const CLOSE_EVENT = 'close'
 let closeHandler = ()=>{}
 
 class HttpResponse extends Writable {
-  constructor (uResponse) {
+  constructor (uResponse, reqWrapper) {
     super()
 
     const oldThisOn = this.on.bind(this)
@@ -36,6 +36,7 @@ class HttpResponse extends Writable {
     this.res.onAborted(() => {
       this.finished = this.res.finished = true
       closeHandler()
+      reqWrapper.closeHandler()
     })
 
     this.on('pipe', (_) => {

--- a/src/server.js
+++ b/src/server.js
@@ -51,8 +51,8 @@ module.exports = (config = {}) => {
     }
   })
 
-  uServer._date = new Date().toUTCString()
-  const timer = setInterval(() => (uServer._date = new Date().toUTCString()), 1000)
+  // uServer._date = new Date().toUTCString()
+  // const timer = setInterval(() => (uServer._date = new Date().toUTCString()), 1000)
 
   class Facade extends EventEmitter {
     constructor () {

--- a/src/server.js
+++ b/src/server.js
@@ -23,8 +23,8 @@ module.exports = (config = {}) => {
   const uServer = uWS[appType](config).any('/*', (res, req) => {
     res.finished = false
 
-    const reqWrapper = new HttpRequest(req, res)
-    const resWrapper = new HttpResponse(res)
+    const reqWrapper = new HttpRequest(req)
+    const resWrapper = new HttpResponse(res, reqWrapper)
 
     reqWrapper.res = resWrapper
     resWrapper.req = reqWrapper

--- a/src/server.js
+++ b/src/server.js
@@ -23,8 +23,8 @@ module.exports = (config = {}) => {
   const uServer = uWS[appType](config).any('/*', (res, req) => {
     res.finished = false
 
-    const reqWrapper = new HttpRequest(req)
-    const resWrapper = new HttpResponse(res, uServer, config)
+    const reqWrapper = new HttpRequest(req, res)
+    const resWrapper = new HttpResponse(res)
 
     reqWrapper.res = resWrapper
     resWrapper.req = reqWrapper


### PR DESCRIPTION
recently in fastify v3.28 and v4, they use `res.write` to send payload before calling `res.end` and it causes problem that your request in browser can't receive data and the status will be pending forever. I found out that it because you write headers in `res.end` so if we use `res.write`, it means the server will be send header after sending data and that what cases the problem (i don't know about pending part, probably from uWs itself). Anyway, i only add `writeAllHeaders` in write method.