### PR TITLE
[Chore] Update uWebSockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "14"
   - "16"
+  - "18"
 
 install: 
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: focal
 language: node_js
 node_js:
   - "16"
   - "18"
 
-install: 
+install:
   - npm run lint
   - npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "low-http-server",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "HTTP Server implementation on top of uWebSocket.js",
   "main": "src/server.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "uwebsockets"
   ],
   "engines": {
-    "node": ">=14.x"
+    "node": ">14.x"
   },
   "author": "Rolando Santamaria Maso <kyberneees@gmail.com>",
   "contributors": [
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/jkyberneees/low-http-server#readme",
   "dependencies": {
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.10.0"
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.16.0"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/jkyberneees/low-http-server#readme",
   "dependencies": {
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.16.0"
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.14.0"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "uwebsockets"
   ],
   "engines": {
-    "node": ">14.x"
+    "node": ">=16.x"
   },
   "author": "Rolando Santamaria Maso <kyberneees@gmail.com>",
   "contributors": [


### PR DESCRIPTION
This `PR` updates :

+ `uWebSockets` to **v20.14.0**
+ bump version to `v4.2`
+ switch CI from ubuntu **16.04** -> **20.04**

For details, see https://github.com/uNetworking/uWebSockets.js/releases/tag/v20.14.0

⚠️  It drop node 14.x support

cc @jkyberneees 
